### PR TITLE
Update IB multi-model predict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ log/
 */.env.dev
 */basechem/main/tests/testdata/tmp
 basechem/common/mmpdb_data/cache.fragdb
+basechem/common/ESP_DNN/core*
+basechem/common/ESP_DNN/qemu*

--- a/basechem/common/constants.py
+++ b/basechem/common/constants.py
@@ -21,3 +21,15 @@ TORSION_ALERTS_PROP = "TorsionAlerts(RotBondIndices TorsionIndices TorsionAngle 
 TORSION_ALERTS_ENERGY_PROP = "TotalEnergy"
 ADMIN_FAILURE = "Admin Failure"
 ADMIN_NOTIFICATION = "Admin Notification"
+
+# IB Model Names
+IB_LOGD = "denali_logd"
+IB_HLM = "denali_hlm"
+IB_RLM = "denali_rlm"
+IB_PERM = "denali_perm_mdck_mdr1"
+IB_EFFLUX = "denali_efflux_mdck_mdr1"
+IB_KSOL = "denali_kinetic_solubility"
+IB_APKA = "generic_apka"
+IB_BPKA = "generic_bpka"
+
+ALL_IB_MODELS = [IB_LOGD, IB_HLM, IB_RLM, IB_PERM, IB_EFFLUX, IB_KSOL, IB_APKA, IB_BPKA]

--- a/basechem/common/constants.py
+++ b/basechem/common/constants.py
@@ -23,12 +23,12 @@ ADMIN_FAILURE = "Admin Failure"
 ADMIN_NOTIFICATION = "Admin Notification"
 
 # IB Model Names
-IB_LOGD = "denali_logd"
-IB_HLM = "denali_hlm"
-IB_RLM = "denali_rlm"
-IB_PERM = "denali_perm_mdck_mdr1"
-IB_EFFLUX = "denali_efflux_mdck_mdr1"
-IB_KSOL = "denali_kinetic_solubility"
+IB_LOGD = "generic_logd"
+IB_HLM = "generic_hlm"
+IB_RLM = "generic_rlm"
+IB_PERM = "generic_perm_mdck_mdr1"
+IB_EFFLUX = "generic_efflux_mdck_mdr1"
+IB_KSOL = "generic_kinetic_solubility"
 IB_APKA = "generic_apka"
 IB_BPKA = "generic_bpka"
 

--- a/basechem/common/mocks/mock_inductive_utils.py
+++ b/basechem/common/mocks/mock_inductive_utils.py
@@ -1,65 +1,124 @@
 from rdkit import Chem
 
+from basechem.common.constants import (
+    IB_EFFLUX,
+    IB_HLM,
+    IB_KSOL,
+    IB_LOGD,
+    IB_PERM,
+    IB_RLM,
+)
 
-def mock_run_inductive_lm_predict(input_file, species, image=False):
+
+def mock_get_ib_predictions(input_file, models, images=True):
     """
-    Mock for `run_inductive_lm_predict` to use in all test cases except those in `test_inductive_utils.py`
+    Mock for `get_ib_predictions` to use in all test cases except those in `test_inductive_utils.py`
     """
+    interp_image = "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII=="
+    probs_image = "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII=="
+
     suppl = Chem.SDMolSupplier(input_file)
-    return_data = []
-    for mol in suppl:
-        compound_data = {}
-        if species == "R":
-            compound_data = {
-                "name": mol.GetProp("_Name"),
-                "prediction": "54",
-                "measured": "",
-                "out_of_domain": "True",
-                "latest_data_date": "2022-11-25",
-                "model_version": "2.0.0",
-                "interp_image": "",
-                "probs_image": "",
-                "probs_list": [0.049, 0.051, 0.9],
-            }
-        elif species == "H":
-            compound_data = {
-                "name": mol.GetProp("_Name"),
-                "prediction": "20",
-                "measured": "",
-                "out_of_domain": "True",
-                "latest_data_date": "2022-11-25",
-                "model_version": "2.0.0",
-                "interp_image": "",
-                "probs_image": "",
-                "probs_list": [0.2, 0.4, 0.4],
-            }
-        if image:
-            compound_data[
-                "interp_image"
-            ] = "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII=="
-            compound_data[
-                "probs_image"
-            ] = "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII=="
-        return_data.append(compound_data)
-    return return_data
+    return_data = {}
+    for model in models:
+        return_data[model] = []
+        for mol in suppl:
+            if model == IB_RLM:
+                compound_data = {
+                    "name": mol.GetProp("_Name"),
+                    "prediction": "54.04",
+                    "measured": "",
+                    "out_of_domain": "True",
+                    "latest_data_date": "2022-11-25",
+                    "model_version": "2.0.0",
+                    "interp_image": "",
+                    "probs_image": "",
+                    "probs_list": [0.049, 0.051, 0.9],
+                }
+                if images:
+                    compound_data["interp_image"] = interp_image
+                    compound_data["probs_image"] = probs_image
+                return_data[model].append(compound_data)
+            if model == IB_HLM:
+                compound_data = {
+                    "name": mol.GetProp("_Name"),
+                    "prediction": "20.53",
+                    "measured": "",
+                    "out_of_domain": "True",
+                    "latest_data_date": "2022-11-25",
+                    "model_version": "2.0.0",
+                    "interp_image": "",
+                    "probs_image": "",
+                    "probs_list": [0.2, 0.4, 0.4],
+                }
+                if images:
+                    compound_data["interp_image"] = interp_image
+                    compound_data["probs_image"] = probs_image
+                return_data[model].append(compound_data)
 
+            if model == IB_LOGD:
+                compound_data = {
+                    "name": mol.GetProp("_Name"),
+                    "prediction": "2.30",
+                    "measured": "2.22",
+                    "out_of_domain": "",
+                    "latest_data_date": "2022-11-25",
+                    "model_version": "2.0.0",
+                    "interp_image": "",
+                    "probs_image": "",
+                    "probs_list": [],
+                }
+                return_data[model].append(compound_data)
 
-def mock_run_inductive_alogd_predict(input_file):
-    """
-    Mock for `run_inductive_alogd_predict` to use in all test cases except those in `test_inductive_utils.py`
-    """
-    suppl = Chem.SDMolSupplier(input_file)
-    return_data = []
-    for mol in suppl:
-        compound_data = {
-            "name": mol.GetProp("_Name"),
-            "prediction": "2.30",
-            "latest_data_date": "2022-11-25",
-            "model_version": "2.0.0",
-            "measured": "2.22",
-        }
+            if model == IB_EFFLUX:
+                compound_data = {
+                    "name": mol.GetProp("_Name"),
+                    "prediction": "0.5",
+                    "measured": "",
+                    "out_of_domain": "False",
+                    "latest_data_date": "2024-01-01",
+                    "model_version": "1.1.0",
+                    "interp_image": "",
+                    "probs_image": "",
+                    "probs_list": [0.99, 0.003, 0.0008],
+                }
+                if images:
+                    compound_data["interp_image"] = interp_image
+                    compound_data["probs_image"] = probs_image
+                return_data[model].append(compound_data)
 
-        return_data.append(compound_data)
+            if model == IB_PERM:
+                compound_data = {
+                    "name": mol.GetProp("_Name"),
+                    "prediction": "0.12",
+                    "measured": "",
+                    "out_of_domain": "False",
+                    "latest_data_date": "2024-01-01",
+                    "model_version": "1.0.0",
+                    "interp_image": "",
+                    "probs_image": "",
+                    "probs_list": [0.680, 0.086, 0.233],
+                }
+                if images:
+                    compound_data["interp_image"] = interp_image
+                    compound_data["probs_image"] = probs_image
+                return_data[model].append(compound_data)
+
+            if model == IB_KSOL:
+                compound_data = {
+                    "name": mol.GetProp("_Name"),
+                    "prediction": "6.5",
+                    "measured": "",
+                    "out_of_domain": "True",
+                    "latest_data_date": "2024-10-29",
+                    "model_version": "1.0.0",
+                    "interp_image": "",
+                    "probs_image": "",
+                    "probs_list": [0.586, 0.311, 0.101],
+                }
+                if images:
+                    compound_data["interp_image"] = interp_image
+                    compound_data["probs_image"] = probs_image
+                return_data[model].append(compound_data)
 
     return return_data
 

--- a/basechem/common/tests/base.py
+++ b/basechem/common/tests/base.py
@@ -14,8 +14,7 @@ from rdkit import Chem
 
 from basechem.common.mmpdb_utils import initialize_mmpdb
 from basechem.common.mocks.mock_inductive_utils import (
-    mock_run_inductive_alogd_predict,
-    mock_run_inductive_lm_predict,
+    mock_get_ib_predictions,
     mock_update_inductive_logd_data,
 )
 from basechem.common.mocks.mock_mayachem_utils import mock_generate_torsion_alerts_NOOP
@@ -371,21 +370,16 @@ class BasechemTestCase(BasechemNoMockTestCase):
     def setUpClass(cls):
         super().setUpClass()
         # Set up mock patch for InductiveBio
-        cls.main_run_inductive_lm_predict_patch = mock.patch(
-            "basechem.main.models.compound_models.run_inductive_lm_predict",
-            mock_run_inductive_lm_predict,
+        cls.main_get_ib_predictions_patch = mock.patch(
+            "basechem.main.models.compound_models.get_ib_predictions",
+            mock_get_ib_predictions,
         )
-        cls.common_run_inductive_lm_predict_patch = mock.patch(
-            "basechem.common.propcalc_utils.run_inductive_lm_predict",
-            mock_run_inductive_lm_predict,
+        cls.common_get_ib_predictions_patch = mock.patch(
+            "basechem.common.propcalc_utils.get_ib_predictions",
+            mock_get_ib_predictions,
         )
-        cls.main_run_inductive_alogd_predict_patch = mock.patch(
-            "basechem.main.models.compound_models.run_inductive_alogd_predict",
-            mock_run_inductive_alogd_predict,
-        )
-        cls.main_run_inductive_lm_predict_patch.start()
-        cls.common_run_inductive_lm_predict_patch.start()
-        cls.main_run_inductive_alogd_predict_patch.start()
+        cls.main_get_ib_predictions_patch.start()
+        cls.common_get_ib_predictions_patch.start()
 
         # Set up mock patch for Mayachem
         cls.generate_torsion_alerts_patch = mock.patch(
@@ -407,9 +401,8 @@ class BasechemTestCase(BasechemNoMockTestCase):
     def tearDownClass(cls):
         super().tearDownClass()
         # Tear down mock patch for InductiveBio
-        cls.main_run_inductive_lm_predict_patch.stop()
-        cls.common_run_inductive_lm_predict_patch.stop()
-        cls.main_run_inductive_alogd_predict_patch.stop()
+        cls.main_get_ib_predictions_patch.stop()
+        cls.common_get_ib_predictions_patch.stop()
 
         # Tear down mock patch for Mayachem
         cls.generate_torsion_alerts_patch.stop()

--- a/basechem/common/tests/test_inductive_utils.py
+++ b/basechem/common/tests/test_inductive_utils.py
@@ -1,146 +1,104 @@
 from django.core import mail
 from django.test import tag
 
+from basechem.common.constants import IB_HLM, IB_LOGD, IB_RLM
 from basechem.common.inductive_utils import (
-    run_inductive_alogd_predict,
-    run_inductive_lm_predict,
+    get_ib_predictions,
     update_inductive_logd_data,
 )
-from basechem.common.mocks.mock_inductive_utils import (
-    mock_run_inductive_alogd_predict,
-    mock_run_inductive_lm_predict,
-)
+from basechem.common.mocks.mock_inductive_utils import mock_get_ib_predictions
 from basechem.common.tests.base import BasechemNoMockTestCase
 
 
 @tag("local", "inductive", "external")
 class InductiveBioUtilsTestCase(BasechemNoMockTestCase):
-    def test_run_inductive_lm_predict(self):
+    def test_get_ib_predictions(self):
         """
-        Tests `run_inductive_lm_predict` and tests that output of `mock_run_inductive_lm_predict`
-        tracks with `run_inductive_lm_predict`
+        Tests `get_ib_predictions` and tests that output of `mock_get_ib_predictions`
+        tracks with `get_ib_predictions`
         """
         input_file = "basechem/main/tests/testdata/test_onecomp.sdf"
-        with self.subTest("Rat, no image"):
-            result = run_inductive_lm_predict(input_file, "R", False)
-            mock_result = mock_run_inductive_lm_predict(input_file, "R", False)
-
-            # Check that lists are the same length, then compare the first element
-            self.assertEqual(len(result), len(mock_result))
-            result = result[0]
-            mock_result = mock_result[0]
-
-            # "prediction" can be cast integer
-            self.assertEqual(int, type(int(result["prediction"])))
-            # "out_of_domain" can be cast as a bool
-            self.assertEqual(bool, type(bool(result["out_of_domain"])))
-            # "interp_image" should be the empty string
-            self.assertEqual(result["interp_image"], "")
-            # "probs_image" should be the empty string
-            self.assertEqual(result["probs_image"], "")
-
-            # Check that the mock result has the correct format
-            self.assertEqual(mock_result.keys(), result.keys())
-            for key in mock_result.keys():
-                self.assertEqual(type(mock_result[key]), type(result[key]))
-            self.assertEqual(mock_result["interp_image"], "")
-            self.assertEqual(mock_result["probs_image"], "")
 
         with self.subTest("Rat, image"):
-            result = run_inductive_lm_predict(input_file, "R", True)
-            mock_result = mock_run_inductive_lm_predict(input_file, "R", True)
+            result = get_ib_predictions(input_file, [IB_RLM])
+            mock_result = mock_get_ib_predictions(input_file, [IB_RLM])
 
-            # Check that lists are the same length, then compare the first element
             self.assertEqual(len(result), len(mock_result))
-            result = result[0]
-            mock_result = mock_result[0]
+            result = result[IB_RLM][0]
+            mock_result = mock_result[IB_RLM][0]
 
-            # "prediction" can be cast integer
-            self.assertEqual(int, type(int(result["prediction"])))
-            # "out_of_domain" can be cast as a bool
+            self.assertEqual(float, type(float(result["prediction"])))
             self.assertEqual(bool, type(bool(result["out_of_domain"])))
-            # images should be base64 images of at least 50 chars
-            self.assertEqual(str, type(result["interp_image"]))
             self.assertTrue(len(result["interp_image"]) > 50)
-            self.assertEqual(str, type(result["probs_image"]))
             self.assertTrue(len(result["probs_image"]) > 50)
 
-            # Check that the mock result has the correct format
+            # Check that the mock result has the correct format but not the same data
             self.assertEqual(mock_result.keys(), result.keys())
             for key in mock_result.keys():
                 self.assertEqual(type(mock_result[key]), type(result[key]))
             self.assertTrue(len(mock_result["interp_image"]) > 50)
             self.assertTrue(len(mock_result["probs_image"]) > 50)
 
-        with self.subTest("Human, no image"):
-            result = run_inductive_lm_predict(input_file, "H", False)
-            mock_result = mock_run_inductive_lm_predict(input_file, "H", False)
+        with self.subTest("Two models, no image"):
+            models = [IB_RLM, IB_HLM]
+            result = get_ib_predictions(input_file, models, images=False)
+            mock_result = mock_get_ib_predictions(input_file, models, images=False)
 
-            # Check that lists are the same length, then compare the first element
+            self.assertEqual(len(result), 2)
+            self.assertEqual(list(result.keys()), models)
+            self.assertEqual(mock_result.keys(), result.keys())
+            self.assertEqual(len(result[models[0]]), len(mock_result[models[0]]))
+
+            for model, prediction in result.items():
+                self.assertTrue(model in models)
+                self.assertEqual(len(prediction), 1)
+                for pred in prediction:
+                    self.assertEqual(float, type(float(pred["prediction"])))
+                    self.assertEqual(bool, type(bool(pred["out_of_domain"])))
+                    self.assertEqual(pred["interp_image"], "")
+                    self.assertEqual(pred["probs_image"], "")
+
+            for model, prediction in mock_result.items():
+                self.assertTrue(model in models)
+                self.assertEqual(len(prediction), 1)
+                for pred in prediction:
+                    self.assertEqual(float, type(float(pred["prediction"])))
+                    self.assertEqual(bool, type(bool(pred["out_of_domain"])))
+                    self.assertEqual(pred["interp_image"], "")
+                    self.assertEqual(pred["probs_image"], "")
+
+        with self.subTest("logd"):
+            result = get_ib_predictions(input_file, [IB_LOGD], images=False)
+            mock_result = mock_get_ib_predictions(input_file, [IB_LOGD], images=False)
+
             self.assertEqual(len(result), len(mock_result))
-            result = result[0]
-            mock_result = mock_result[0]
+            self.assertEqual(len(result), 1)
+            result = result[IB_LOGD][0]
+            mock_result = mock_result[IB_LOGD][0]
 
-            # "prediction" can be cast integer
-            self.assertEqual(int, type(int(result["prediction"])))
-            # "out_of_domain" can be cast as a bool
-            self.assertEqual(bool, type(bool(result["out_of_domain"])))
-            # "interp_image" should be the empty string
-            self.assertEqual(result["interp_image"], "")
-            # "probs_image" should be the empty string
-            self.assertEqual(result["probs_image"], "")
-
-            # Check that the mock result has the correct format
+            self.assertEqual(float, type(float(result["prediction"])))
             self.assertEqual(mock_result.keys(), result.keys())
             for key in mock_result.keys():
                 self.assertEqual(type(mock_result[key]), type(result[key]))
-            self.assertEqual(mock_result["interp_image"], "")
-            self.assertEqual(mock_result["probs_image"], "")
 
-        with self.subTest("Human, image"):
-            result = run_inductive_lm_predict(input_file, "H", True)
-            mock_result = mock_run_inductive_lm_predict(input_file, "H", True)
+        with self.subTest("logd, multi-compound"):
+            input_file = "basechem/main/tests/testdata/test_mmps_w_data.sdf"
+            result = get_ib_predictions(input_file, [IB_LOGD], images=False)
+            mock_result = mock_get_ib_predictions(input_file, [IB_LOGD], images=False)
 
-            # Check that lists are the same length, then compare the first element
-            self.assertEqual(len(result), len(mock_result))
-            result = result[0]
-            mock_result = mock_result[0]
-
-            # "prediction" can be cast integer
-            self.assertEqual(int, type(int(result["prediction"])))
-            # "out_of_domain" can be cast as a bool
-            self.assertEqual(bool, type(bool(result["out_of_domain"])))
-            # images should be base64 images of at least 50 chars
-            self.assertEqual(str, type(result["interp_image"]))
-            self.assertTrue(len(result["interp_image"]) > 50)
-            self.assertEqual(str, type(result["probs_image"]))
-            self.assertTrue(len(result["probs_image"]) > 50)
-
-            # Check that the mock result has the correct format
+            self.assertEqual(len(result), 1)
             self.assertEqual(mock_result.keys(), result.keys())
-            for key in mock_result.keys():
-                self.assertEqual(type(mock_result[key]), type(result[key]))
-            self.assertTrue(len(mock_result["interp_image"]) > 50)
-            self.assertTrue(len(mock_result["probs_image"]) > 50)
+            self.assertEqual(len(result[IB_LOGD]), 14)
+            self.assertEqual(len(result[IB_LOGD]), len(mock_result[IB_LOGD]))
 
-    def test_run_inductive_alogd_predict(self):
-        """
-        Tests `run_inductive_alogd_predict` and tests that output of `mock_run_inductive_alogd_predict`
-        tracks with `run_inductive_alogd_predict`
-        """
-        input_file = "basechem/main/tests/testdata/test_onecomp.sdf"
-
-        result = run_inductive_alogd_predict(input_file)
-        mock_result = mock_run_inductive_alogd_predict(input_file)
-
-        self.assertEqual(len(result), len(mock_result))
-        result = result[0]
-        mock_result = mock_result[0]
-
-        self.assertEqual(float, type(float(result["prediction"])))
-        self.assertEqual(mock_result.keys(), result.keys())
-        for key in mock_result.keys():
-            self.assertEqual(type(mock_result[key]), type(result[key]))
+            for model, prediction in result.items():
+                self.assertEqual(model, IB_LOGD)
+                self.assertEqual(len(prediction), 14)
+                for pred in prediction:
+                    self.assertEqual(float, type(float(pred["prediction"])))
+                    self.assertEqual(bool, type(bool(pred["out_of_domain"])))
+                    self.assertEqual(pred["interp_image"], "")
+                    self.assertEqual(pred["probs_image"], "")
 
     def test_update_inductive_logd_data(self):
         """

--- a/basechem/common/tests/test_propcalc_utils.py
+++ b/basechem/common/tests/test_propcalc_utils.py
@@ -82,13 +82,13 @@ class PropCalcUtilsTestCase(BasechemTestCase):
         )
         self.assertEqual(
             lines[1],
-            f"DN001,Inductive Bio GCNN,,,,out-of-domain,,0.200,,,{date},2.0.0: 2022-11-25,20,,54,\n",
+            f"DN001,Inductive Bio GCNN,,,,out-of-domain,,0.200,,,{date},2.0.0: 2022-11-25,20.53,,54.04,\n",
         )
         self.assertEqual(
             lines[2],
-            f"DN002,Inductive Bio GCNN,,,,out-of-domain,,0.200,,,{date},2.0.0: 2022-11-25,20,,54,\n",
+            f"DN002,Inductive Bio GCNN,,,,out-of-domain,,0.200,,,{date},2.0.0: 2022-11-25,20.53,,54.04,\n",
         )
         self.assertEqual(
             lines[3],
-            f"DN003,Inductive Bio GCNN,,,,out-of-domain,,0.200,,,{date},2.0.0: 2022-11-25,20,,54,\n",
+            f"DN003,Inductive Bio GCNN,,,,out-of-domain,,0.200,,,{date},2.0.0: 2022-11-25,20.53,,54.04,\n",
         )

--- a/basechem/main/assay_emailer_utils.py
+++ b/basechem/main/assay_emailer_utils.py
@@ -53,8 +53,9 @@ def process_new_data(project, assay_data_df, analyses):
             )
             try:
                 assayed_dns = assay_data_df["DN_ID"].unique().tolist()
-                assay_data_col.find_mmps()
-                assay_data_col.update_mmp_dtx_avg_assay_data(assayed_dns)
+                # TODO: Fix MMPs for NICO but for now there is no DB so don't run this
+                # assay_data_col.find_mmps()
+                # assay_data_col.update_mmp_dtx_avg_assay_data(assayed_dns)
             except:
                 # Don't let an MMP error stop the email from being sent
                 pass

--- a/basechem/main/assay_emailer_utils.py
+++ b/basechem/main/assay_emailer_utils.py
@@ -53,9 +53,8 @@ def process_new_data(project, assay_data_df, analyses):
             )
             try:
                 assayed_dns = assay_data_df["DN_ID"].unique().tolist()
-                # TODO: Fix MMPs for NICO but for now there is no DB so don't run this
-                # assay_data_col.find_mmps()
-                # assay_data_col.update_mmp_dtx_avg_assay_data(assayed_dns)
+                assay_data_col.find_mmps()
+                assay_data_col.update_mmp_dtx_avg_assay_data(assayed_dns)
             except:
                 # Don't let an MMP error stop the email from being sent
                 pass

--- a/basechem/main/constants.py
+++ b/basechem/main/constants.py
@@ -48,6 +48,12 @@ CLOGP = "cLogP"
 ALOGD = "LogD"
 RLM = "RLM"
 HLM = "HLM"
+EFFLUX = "Efflux"
+PERMEABILITY = "Permeability"
+KSOL = "Kinetic Solubility"
+APKA = "Most Acidic pKa"
+BPKA = "Most Basic pKa"
+IB_PROPS = [ALOGD, RLM, HLM, EFFLUX, PERMEABILITY, KSOL, APKA, BPKA]
 
 ALL_PROPS = [
     ACCEPTORS,
@@ -65,6 +71,11 @@ ALL_PROPS = [
     ALOGD,
     RLM,
     HLM,
+    EFFLUX,
+    PERMEABILITY,
+    KSOL,
+    APKA,
+    BPKA,
 ]
 
 # Max hours to wait for sending an assay email

--- a/basechem/main/forms.py
+++ b/basechem/main/forms.py
@@ -355,16 +355,7 @@ class PropCalcForm(CompoundIntakeForm):
         (TPSA, "TPSA: Topological polar surface area"),
         (CLOGP, "Calculated LogP: LogP is measured at pH where molecule is neutral"),
     ]
-    initial_physiochemical = [MW, TPSA, HLM]
-    if settings.INDUCTIVE_BIO_ENABLED:
-        PHYSIOCHEMICAL_PROPERTIES.extend(
-            [
-                (ALOGD, "LogD: Predicted LodD using the InductiveBio ML model"),
-                (RLM, "RLM: Predicted RLM stability using the InductiveBio ML model"),
-                (HLM, "HLM: Predicted HLM stability using the InductiveBio ML model"),
-            ]
-        )
-        initial_physiochemical.append(ALOGD)
+    initial_physiochemical = [MW, TPSA]
 
     counts = forms.MultipleChoiceField(
         required=False, widget=forms.CheckboxSelectMultiple, choices=COUNTS_PROPERTIES
@@ -376,6 +367,27 @@ class PropCalcForm(CompoundIntakeForm):
         choices=PHYSIOCHEMICAL_PROPERTIES,
         initial=initial_physiochemical,
     )
+
+    if settings.INDUCTIVE_BIO_ENABLED:
+        INDUCTIVE_BIO_PROPERTIES = [
+            (ALOGD, "LogD: Predicted aLodD"),
+            (RLM, "RLM: Predicted RLM stability"),
+            (HLM, "HLM: Predicted HLM stability"),
+            (PERMEABILITY, "Permeability: Predicted MDCK-MDR1 permeability"),
+            (EFFLUX, "Efflux: Predicted MDCK-MDR1 efflux"),
+            (KSOL, "Kinetic Solubility: Predicted kinetic solubility"),
+            (APKA, "Acidic pKa: Predicted most acidic pKa"),
+            (BPKA, "Basic pKa: Predicted most basic pKa"),
+        ]
+
+        initial_predicted = [ALOGD, HLM, EFFLUX]
+
+        predicted = forms.MultipleChoiceField(
+            required=False,
+            widget=forms.CheckboxSelectMultiple,
+            choices=INDUCTIVE_BIO_PROPERTIES,
+            initial=initial_predicted,
+        )
 
 
 ######################

--- a/basechem/main/static/js/propcalc.js
+++ b/basechem/main/static/js/propcalc.js
@@ -69,18 +69,41 @@ function collectSuccessfulPropCalcTask(coPk, ajaxData, _parsedData, _viewer) {
   oldGridItem.remove()
   $('.hover-tooltip').tooltip({trigger:"hover"})
   // Update tooltip text with the latest training date (if inductive props exist)
-  if(ajaxData.taskResult["latest_lm_data_date"]){
+  if(ajaxData.taskResult["latest_rlm_data_date"]){
     const hlmTooltipElement = document.getElementById("hlm-tooltip")
     if(hlmTooltipElement){
-      const hlmTooltip = hlmTooltipElement.getAttribute("data-original-title").replace("?",ajaxData.taskResult.latest_lm_data_date)
+      const hlmTooltip = hlmTooltipElement.getAttribute("data-original-title").replace("?",ajaxData.taskResult.latest_rlm_data_date)
       hlmTooltipElement.setAttribute("data-original-title", hlmTooltip)
-    }
+  }
+  }
+  if(ajaxData.taskResult["latest_hlm_data_date"]){
     const rlmTooltipElement = document.getElementById("rlm-tooltip")
     if(rlmTooltipElement){
-      const rlmTooltip = rlmTooltipElement.getAttribute("data-original-title").replace("?",ajaxData.taskResult.latest_lm_data_date)
+      const rlmTooltip = rlmTooltipElement.getAttribute("data-original-title").replace("?",ajaxData.taskResult.latest_hlm_data_date)
       rlmTooltipElement.setAttribute("data-original-title", rlmTooltip)
-    }  
+    }
   }
+  if(ajaxData.taskResult["latest_efflux_data_date"]){
+    const effluxTooltipElement = document.getElementById("efflux-tooltip");
+    if (effluxTooltipElement) {
+      const effluxTooltip = effluxTooltipElement.getAttribute("data-original-title").replace("?", ajaxData.taskResult.latest_efflux_data_date);
+      effluxTooltipElement.setAttribute("data-original-title", effluxTooltip);
+    }
+  }
+  if(ajaxData.taskResult["latest_permeability_data_date"]){
+    const permTooltipElement = document.getElementById("perm-tooltip");
+    if (permTooltipElement) {
+      const permTooltip = permTooltipElement.getAttribute("data-original-title").replace("?", ajaxData.taskResult.latest_permeability_data_date);
+      permTooltipElement.setAttribute("data-original-title", permTooltip);
+    }
+  }
+  if(ajaxData.taskResult["latest_kinetic_solubility_data_date"]){
+    const ksolTooltipElement = document.getElementById("ksol-tooltip");
+    if (ksolTooltipElement) {
+      const ksolTooltip = ksolTooltipElement.getAttribute("data-original-title").replace("?", ajaxData.taskResult.latest_kinetic_solubility_data_date);
+      ksolTooltipElement.setAttribute("data-original-title", ksolTooltip);
+    }
+  }  
   if(ajaxData.taskResult["latest_logd_data_date"]){
     const logdTooltipElement = document.getElementById("logd-tooltip")
     if(logdTooltipElement){

--- a/basechem/main/templates/main/propcalc/table.html
+++ b/basechem/main/templates/main/propcalc/table.html
@@ -18,6 +18,12 @@
                 <span id="hlm-tooltip" class="hover-tooltip icon question-mark bg-orange" data-toggle="tooltip" data-placement="bottom" data-html=true title="A border around the number indicates a measured value. This model is built with data through ?. Values are colored using this scale: <br> <img src='{% static 'images/propcalc/hlm-color-legend.svg' %}' width=200px />"></span>
               {% elif "RLM Prediction" == prop %}
                 <span id="rlm-tooltip" class="hover-tooltip icon question-mark bg-orange" data-toggle="tooltip" data-placement="bottom" data-html=true title="A border around the number indicates a measured value. This model is built with data through ?. Values are colored using this scale: <br> <img src='{% static 'images/propcalc/rlm-color-legend.svg' %}' width=200px />"></span>
+              {% elif "Efflux Prediction" == prop %}
+                <span id="efflux-tooltip" class="hover-tooltip icon question-mark bg-orange" data-toggle="tooltip" data-placement="bottom" data-html=true title="A border around the number indicates a measured value. This model is built with data through ?."></span>
+              {% elif "Permeability Prediction" == prop %}
+                <span id="perm-tooltip" class="hover-tooltip icon question-mark bg-orange" data-toggle="tooltip" data-placement="bottom" data-html=true title="A border around the number indicates a measured value. This model is built with data through ?."></span>
+              {% elif "Kinetic Solubility Prediction" == prop %}
+                <span id="ksol-tooltip" class="hover-tooltip icon question-mark bg-orange" data-toggle="tooltip" data-placement="bottom" data-html=true title="A border around the number indicates a measured value. This model is built with data through ?."></span>
               {% endif %}
             </div>
         {% endfor %}

--- a/basechem/main/templates/main/propcalc/table_row.html
+++ b/basechem/main/templates/main/propcalc/table_row.html
@@ -8,6 +8,8 @@
       {% with value=property_results|dict_get:co.pk|get_propcalc_val:prop %}
         {% if "LogD" in prop %}
           <td><p class="{{ value|pred_type }} {{ value|first|color_filter:prop }}">{{ value|first }}</p></td>
+        {% elif "pKa" in prop %}
+          <td><p class="{{ value|pred_type }}">{{ value|first }}</p></td>
         {% elif "TPSA" in prop %}
           <td><p class="{{ value|color_filter:prop }}">{{ value }}</p></td>
         {% elif "Prediction" in prop %}

--- a/basechem/main/templatetags/tags.py
+++ b/basechem/main/templatetags/tags.py
@@ -159,6 +159,33 @@ def color_filter(value, prop):
         else:
             return "green"
 
+    if prop == "Efflux Prediction":
+        value = float(value)
+        if value > 20:
+            return "red"
+        elif 5 < value <= 20:
+            return "orange"
+        else:
+            return "green"
+
+    if prop == "Permeability Prediction":
+        value = float(value)
+        if 0 < value < 2:
+            return "red"
+        elif 2 <= value < 10:
+            return "orange"
+        else:
+            return "green"
+
+    if prop == "Kinetic Solubility Prediction":
+        value = float(value)
+        if 0 < value < 10:
+            return "red"
+        elif 10 <= value <= 100:
+            return "orange"
+        else:
+            return "green"
+
     if prop == "assay_result" and value:
         value = float(value)
         if value <= 1:
@@ -192,20 +219,19 @@ def get_propcalc_val(prop_dict, prop):
     prop = prop.lower().replace(" ", "_")
     value = prop_dict.get(prop, "")
 
+    prefix = prop.split("_")[:-1]
+    if prefix:
+        prefix = prefix[0]
+    if prefix == "kinetic":
+        prefix = "kinetic_solubility"
+
     if "probabilities" in prop:
-        prefix = re.match("(r|h)lm", prop).group(0)
         # Add the out of domain flag to the value
         ood_flag = eval(prop_dict.get(f"{prefix}_ood"))
         value = [value, ood_flag]
 
     if "prediction" in prop:
-        prefix = prop
         interp_img = None
-
-        match = re.match("(r|h)lm", prop)
-        if match:
-            prefix = re.match("(r|h)lm", prop).group(0)
-
         # Show measured value as 'value' if exists
         measured = prop_dict.get(f"{prefix}_measured")
         is_measured = False

--- a/basechem/main/tests/test_models/test_collection_model.py
+++ b/basechem/main/tests/test_models/test_collection_model.py
@@ -755,7 +755,7 @@ class CollectionTestCase(BasechemTestCase):
                 v = prop_dict[co.pk]
                 self.assertIn("mw", v)
                 self.assertIn("logd_prediction", v)
-                self.assertNotEqual(co.compound.predict_logd(), None)
+                self.assertNotEqual(co.compound.get_ib_predictions(images=False), None)
 
         with self.subTest("Run LM predictions"):
             cos = self.collection_one_cpd.compound_occurrences.all()

--- a/basechem/main/tests/test_views/test_ajax_views.py
+++ b/basechem/main/tests/test_views/test_ajax_views.py
@@ -357,6 +357,10 @@ class AjaxCollectTaskTestCase(BasechemViewTestMixin, BasechemTestCase):
             "logd_prediction",
             "logd_measured",
             "latest_logd_data_date",
+            "hlm_prediction",
+            "hlm_probability",
+            "efflux_prediction",
+            "efflux_probability",
             "mw",
             "clogp",
         ]

--- a/basechem/main/views/base_views.py
+++ b/basechem/main/views/base_views.py
@@ -166,9 +166,11 @@ class SubmitCompoundsView(LoginRequiredMixin, FormView):
         """
         metadata = {}
         if self.get_form_class() == PropCalcForm:
-            metadata["props_to_show"] = form.cleaned_data.get(
-                "counts", []
-            ) + form.cleaned_data.get("physiochemical", [])
+            metadata["props_to_show"] = (
+                form.cleaned_data.get("counts", [])
+                + form.cleaned_data.get("physiochemical", [])
+                + form.cleaned_data.get("predicted", [])
+            )
 
         if self.get_form_class() == MMPSubmitForm:
             metadata["mmp_analysis"] = {

--- a/basechem/settings/deploy.py
+++ b/basechem/settings/deploy.py
@@ -11,10 +11,10 @@ DOMAIN = os.environ.get("DOMAIN", "*")
 WEBSERVER_ROOT = os.environ.get("WEBSERVER_ROOT", "/home/app/web/")
 
 if ENVIRONMENT == "prod":
-    Q_CLUSTER["workers"] = 8  # default queue
+    Q_CLUSTER["workers"] = 16  # default queue
     Q_CLUSTER["ALT_CLUSTERS"]["fast"][
         "workers"
-    ] = 8  # propcalc and new_collection only rn
+    ] = 16  # propcalc and new_collection only rn
     Q_CLUSTER["ALT_CLUSTERS"]["slow"]["workers"] = 4  # torsion only rn
     INDUCTIVE_VERSION = "latest"
 
@@ -29,11 +29,8 @@ AWS_SESSION_TOKEN = os.environ.get("AWS_SESSION_TOKEN", "")
 DEFAULT_FILE_STORAGE = "basechem.mni_common.storage_backends.MediaStorage"
 STATICFILES_STORAGE = "basechem.mni_common.storage_backends.StaticStorage"
 AWS_S3_REGION_NAME = os.environ.get("AWS_S3_REGION_NAME", "us-west-2")
-AWS_S3_CUSTOM_DOMAIN = "%s.s3.%s.amazonaws.com" % (
-    AWS_STORAGE_BUCKET_NAME,
-    AWS_S3_REGION_NAME,
-)
-AWS_DEFAULT_ACL = "public-read"
+AWS_S3_CUSTOM_DOMAIN = "shore.nicotx.cloud"
+AWS_DEFAULT_ACL = os.environ.get("AWS_DEFAULT_ACL", "public-read")
 
 ##########################################################################################
 #                                    Logger Settings                                     #
@@ -50,9 +47,9 @@ if ENVIRONMENT in ["test", "prod"]:
         region_name=AWS_S3_REGION_NAME,
     )
     # AWS log group that contains the "analytics" and "django" log streams
-    log_group = "/basechem/mni-test/basechem"
+    log_group = "/nico/mni/mni-test/basechem"
     if ENVIRONMENT == "prod":
-        log_group = "/basechem/mni-prod/basechem"
+        log_group = "/nico/mni/mni-prod/basechem"
 
     # Configure django error logging
     LOGGING["formatters"]["aws_error_formatter"] = {
@@ -89,7 +86,7 @@ if ENVIRONMENT in ["test", "prod"]:
 ##########################################################################################
 
 EMAIL_HOST = os.environ.get("EMAIL_HOST", "mail.smtp2go.com")
-EMAIL_HOST_USER = os.environ.get("EMAIL_HOST_USER", "")
+EMAIL_HOST_USER = os.environ.get("EMAIL_HOST_USER", "nicotx")
 EMAIL_HOST_PASSWORD = os.environ.get("EMAIL_HOST_PASSWORD", "")
 EMAIL_USE_TLS = os.environ.get("EMAIL_USE_TLS", True)
 EMAIL_USE_SSL = os.environ.get("EMAIL_USE_SSL", False)
@@ -103,7 +100,9 @@ else:
     default_smtp_port = 25
 EMAIL_PORT = os.environ.get("EMAIL_PORT", default_smtp_port)
 EMAIL_SUBJECT_PREFIX = "[Basechem %s] " % ENVIRONMENT.title()
-DEFAULT_FROM_EMAIL = os.environ.get("DEFAULT_FROM_EMAIL", "")
+DEFAULT_FROM_EMAIL = os.environ.get(
+    "DEFAULT_FROM_EMAIL", "nico-admin@nicotherapeutics.com"
+)
 SERVER_EMAIL = DEFAULT_FROM_EMAIL
 
 ##########################################################################################

--- a/basechem/settings/deploy.py
+++ b/basechem/settings/deploy.py
@@ -29,7 +29,14 @@ AWS_SESSION_TOKEN = os.environ.get("AWS_SESSION_TOKEN", "")
 DEFAULT_FILE_STORAGE = "basechem.mni_common.storage_backends.MediaStorage"
 STATICFILES_STORAGE = "basechem.mni_common.storage_backends.StaticStorage"
 AWS_S3_REGION_NAME = os.environ.get("AWS_S3_REGION_NAME", "us-west-2")
-AWS_S3_CUSTOM_DOMAIN = "shore.nicotx.cloud"
+AWS_S3_CUSTOM_DOMAIN = os.environ.get(
+    "AWS_S3_CUSTOM_DOMAIN",
+    "%s.s3.%s.amazonaws.com"
+    % (
+        AWS_STORAGE_BUCKET_NAME,
+        AWS_S3_REGION_NAME,
+    ),
+)
 AWS_DEFAULT_ACL = os.environ.get("AWS_DEFAULT_ACL", "public-read")
 
 ##########################################################################################
@@ -47,9 +54,9 @@ if ENVIRONMENT in ["test", "prod"]:
         region_name=AWS_S3_REGION_NAME,
     )
     # AWS log group that contains the "analytics" and "django" log streams
-    log_group = "/nico/mni/mni-test/basechem"
+    log_group = "/basechem/mni/mni-test/basechem"
     if ENVIRONMENT == "prod":
-        log_group = "/nico/mni/mni-prod/basechem"
+        log_group = "/basechem/mni/mni-prod/basechem"
 
     # Configure django error logging
     LOGGING["formatters"]["aws_error_formatter"] = {
@@ -86,7 +93,7 @@ if ENVIRONMENT in ["test", "prod"]:
 ##########################################################################################
 
 EMAIL_HOST = os.environ.get("EMAIL_HOST", "mail.smtp2go.com")
-EMAIL_HOST_USER = os.environ.get("EMAIL_HOST_USER", "nicotx")
+EMAIL_HOST_USER = os.environ.get("EMAIL_HOST_USER", "")
 EMAIL_HOST_PASSWORD = os.environ.get("EMAIL_HOST_PASSWORD", "")
 EMAIL_USE_TLS = os.environ.get("EMAIL_USE_TLS", True)
 EMAIL_USE_SSL = os.environ.get("EMAIL_USE_SSL", False)
@@ -100,9 +107,7 @@ else:
     default_smtp_port = 25
 EMAIL_PORT = os.environ.get("EMAIL_PORT", default_smtp_port)
 EMAIL_SUBJECT_PREFIX = "[Basechem %s] " % ENVIRONMENT.title()
-DEFAULT_FROM_EMAIL = os.environ.get(
-    "DEFAULT_FROM_EMAIL", "nico-admin@nicotherapeutics.com"
-)
+DEFAULT_FROM_EMAIL = os.environ.get("DEFAULT_FROM_EMAIL", "")
 SERVER_EMAIL = DEFAULT_FROM_EMAIL
 
 ##########################################################################################

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   web:
     image: basechem_dev:latest

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   web:
     image: basechem_prod:latest


### PR DESCRIPTION
Update inductive_utils to use multi-predict endpoint to easily add new models. Also updates forms and views to show newly available predictive models. 